### PR TITLE
add_date_index

### DIFF
--- a/webapp/sql/100_index.sql
+++ b/webapp/sql/100_index.sql
@@ -1,1 +1,3 @@
 use `isutrain`;
+
+create index date_index on train_timetable_master(date);


### PR DESCRIPTION
```
 Time: 2021-07-24T11:56:44.708844Z
 User@Host: isutrain[isutrain] @ webapp_webapp_1.webapp_default [172.18.0.4]  Id:    10
 Query_time: 1.825157  Lock_time: 0.000029 Rows_sent: 1  Rows_examined: 2807913
SET timestamp=1627127802;
SELECT arrival FROM train_timetable_master WHERE date='2020/01/01' AND train_class='遅いやつ' AND train_name='91' AND station='桐氷野';
```

というスロークエリがあったので、dateにindex貼ってみる。